### PR TITLE
Parsing fail fix: added "." at end of benefactors

### DIFF
--- a/example.txt
+++ b/example.txt
@@ -1,14 +1,14 @@
 # Bill 1: Mom-&-Pop Store, 1970-01-01
-A	BC	2.00	# A paid 2.00, benefiting B and C
-A	A	5.00	# A paid 5.00, but only for themselves
-A	ABC	10.00	# A paid 10.00, and whatever was bought got split evenly.
+A	BC.	2.00	# A paid 2.00, benefiting B and C
+A	A.	5.00	# A paid 5.00, but only for themselves
+A	ABC.	10.00	# A paid 10.00, and whatever was bought got split evenly.
 
 # Bill 2: Hot Dog Stand, 1970-01-02
-B	A	2.00
-B	AB	3.00
+B	A.	2.00
+B	AB.	3.00
 
 # Cash exchange
-C	B	8.88	# C gave B some cash
+C	B.	8.88	# C gave B some cash
 
 # Bill 3: Tickets, Stadium, 1970-01-05
-A,B		AB,2C	44.00	# A and B each paid half of the tickets, which included one for each of them and 2 for C
+A,B		AB,2C.	44.00	# A and B each paid half of the tickets, which included one for each of them and 2 for C


### PR DESCRIPTION
In its current state the provided example won't parse with error:
`Parsing failed:`
`"-" (line 2, column 11):`
`unexpected "\t"`
`expecting ",", "-", digit, "?", "(", "\\" or "."`
`Unterminated entry (entries without a . at the end are not allowed`